### PR TITLE
fix: add predeploys so Medusa works

### DIFF
--- a/echidna-config.yaml
+++ b/echidna-config.yaml
@@ -27,4 +27,4 @@ codeSize: 0x8000
 
 deployer: "0xfffff"
 sender: ["0x10000", "0x20000", "0x30000", "0x40000"]
-deployContracts: [["0x30000", "Dummy"],["0x40000", "Dummy"]]
+deployContracts: [["0x30000", "Dummy1"],["0x40000", "Dummy2"]]

--- a/medusa.json
+++ b/medusa.json
@@ -13,13 +13,13 @@
 		"deployerAddress": "0xfffff",
 		"senderAddresses": [
 			"0x10000",
-			"0x20000",
-			"0x30000"
+			"0x20000"
 		],
 		"blockNumberDelayMax": 60480,
 		"blockTimestampDelayMax": 604800,
 		"blockGasLimit": 125000000,
 		"transactionGasLimit": 12500000,
+		"predeployedContracts": {"Dummy1": "0x30000", "Dummy2": "0x40000"},
 		"testing": {
 			"stopOnFailedTest": true,
 			"stopOnFailedContractMatching": true,

--- a/src/fuzz/oethvault/Dummy.sol
+++ b/src/fuzz/oethvault/Dummy.sol
@@ -6,4 +6,5 @@
  * @dev This contract gets deployed by Echidna. See `echidna-config.yaml`
  * for more details.
  */
-contract Dummy {}
+contract Dummy1 {}
+contract Dummy2 {}


### PR DESCRIPTION
Before Medusa would trigger the assertions that the sender is a contract, but it works as of https://github.com/crytic/medusa/pull/461. The use of `Dummy1` and `Dummy2` is a workaround until duplicates are supported https://github.com/crytic/medusa/issues/39